### PR TITLE
Fix single-value dictionary decoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: go
 
 go:
-- tip
-- 1.11.x
-- 1.10.x
-
-matrix:
-  allow_failures:
-    - go: tip
+- 1.14.x
+- 1.13.x

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/kostya-sh/parquet-go
+
+go 1.14
+
+require github.com/golang/snappy v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=

--- a/parquet/dict.go
+++ b/parquet/dict.go
@@ -28,12 +28,8 @@ func (d *dictDecoder) init(data []byte) error {
 	if w < 0 || w > 32 {
 		return errors.New("dict: invalid bit width")
 	}
-	if w != 0 {
-		d.keysDecoder = newRLEDecoder(w)
-		d.keysDecoder.init(data[1:])
-	} else if d.numValues != 0 {
-		return errors.New("dict: bit-width = 0 for non-empty dictionary")
-	}
+	d.keysDecoder = newRLEDecoder(w)
+	d.keysDecoder.init(data[1:])
 	return nil
 }
 

--- a/parquet/rle.go
+++ b/parquet/rle.go
@@ -45,7 +45,7 @@ type rleDecoder struct {
 
 // newRLEDecoder creates a new RLE decoder with bit-width w
 func newRLEDecoder(w int) *rleDecoder {
-	if w <= 0 || w > 32 {
+	if w < 0 || w > 32 {
 		panic(fmt.Sprintf("invalid bitwidth: %d", w))
 	}
 	return &rleDecoder{
@@ -116,6 +116,8 @@ func (d *rleDecoder) readRLERunValue() error {
 
 func decodeRLEValue(bytes []byte) int32 {
 	switch len(bytes) {
+	case 0:
+		return 0
 	case 1:
 		return int32(bytes[0])
 	case 2:

--- a/parquet/type_float_test.go
+++ b/parquet/type_float_test.go
@@ -45,18 +45,3 @@ func TestEmptyFloatDictDecoder(t *testing.T) {
 		t.Errorf("error expected when decoding from a dictionary with no values")
 	}
 }
-
-func TestFloatDictDecoderErrors(t *testing.T) {
-	d := &floatDictDecoder{
-		dictDecoder: dictDecoder{vd: &floatPlainDecoder{}},
-	}
-
-	if err := d.initValues([]byte{0x00, 0x00, 0x00, 0x00}, 1); err != nil {
-		t.Fatalf("Error in initValues: %s", err)
-	}
-
-	// test case found with go-fuzz
-	if err := d.init([]byte{0x00}); err == nil {
-		t.Errorf("error expected in init (bit width = 0 for non-empty dictionary)")
-	}
-}

--- a/parquet/type_int96_test.go
+++ b/parquet/type_int96_test.go
@@ -12,3 +12,27 @@ func TestInt96PlainDecoder(t *testing.T) {
 		},
 	})
 }
+
+func TestInt96DictDecoder(t *testing.T) {
+	d := &int96DictDecoder{
+		dictDecoder: dictDecoder{vd: &int96PlainDecoder{}},
+	}
+
+	ent := Int96{0x00, 0x58, 0x47, 0xf8, 0xd, 0x00, 0x00, 0x00, 0x6c, 0x75, 0x25, 0x00}
+	if err := d.initValues(ent[:], 1); err != nil {
+		t.Fatalf("error in initValues: %s", err)
+	}
+
+	if err := d.init([]byte{0x00, 0x98, 0x06}); err != nil {
+		t.Fatalf("error in init: %s", err)
+	}
+
+	dst := make([]Int96, 1)
+	if err := d.decode(dst); err != nil {
+		t.Fatalf("error in decode: %s", err)
+	}
+
+	if dst[0] != ent {
+		t.Fatalf("expected %v to equal %v", dst[0], ent)
+	}
+}


### PR DESCRIPTION
Currently, decoding `RLE_DICTIONARY` encoded columns with a single dictionary value fail with `dict: bit-width = 0 for non-empty dictionary`. I have attached a fix and a test case + added a go.mod.